### PR TITLE
Scrum 54 upload backend add basic endpoint to mitigate cold start

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from botocore.exceptions import ClientError
 import psycopg2
 from contextlib import asynccontextmanager
+from datetime import datetime
 
 
 load_dotenv()
@@ -253,3 +254,11 @@ def fetch_image_data():
 #     #     img["link"] = f"https://e16d722126ccef480a24b7cc683d3e35.r2.cloudflarestorage.com/cloud-test-bucket/{img['file_name']}"  # Link expires in 1 hour
 #     # Render the template with the fetched data
 #     return templates.TemplateResponse("index.html", {"request": request, "images": data})
+
+
+@app.get("/start")
+async def start_endpoint():
+    """
+    Returns the current server datetime.
+    """
+    return {"current_datetime": datetime.now()}


### PR DESCRIPTION
This pull request introduces a new endpoint to the application and includes a minor import addition. The most important changes are the addition of the `/start` endpoint to return the current server datetime and the import of the `datetime` module to support this functionality.

### New Feature: `/start` Endpoint
* Added a new endpoint `/start` in `main.py` that asynchronously returns the current server datetime. This provides a simple API for checking server time.

### Supporting Changes
* Imported the `datetime` module in `main.py` to enable the functionality for the `/start` endpoint.