### PR TITLE
merge to main

### DIFF
--- a/.github/workflows/ACR-ACI-push.yml
+++ b/.github/workflows/ACR-ACI-push.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - main
+name: ACR-ACI-push
+
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+        # checkout the repo
+        - name: 'Checkout GitHub Action'
+          uses: actions/checkout@main
+          
+        - name: 'Login via Azure CLI'
+          uses: azure/login@v1
+          with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+        
+        - name: 'Build and push image'
+          uses: azure/docker-login@v1
+          with:
+            login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+            username: ${{ secrets.REGISTRY_USERNAME }}
+            password: ${{ secrets.REGISTRY_PASSWORD }}
+        - run: |
+            docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/roaportuploadbackend:${{ github.sha }}
+            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/roaportuploadbackend:${{ github.sha }}
+
+        - name: 'Deploy to Azure Container Instances'
+          uses: 'azure/aci-deploy@v1'
+          with:
+            resource-group: ${{ secrets.RESOURCE_GROUP }}
+            dns-name-label: ${{ secrets.RESOURCE_GROUP }}${{ github.run_number }}
+            image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/roaportuploadbackend:${{ github.sha }}
+            registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+            registry-username: ${{ secrets.REGISTRY_USERNAME }}
+            registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+            name: roaport-upload-backend-instance
+            location: 'italy north'

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from botocore.exceptions import ClientError
 import psycopg2
 from contextlib import asynccontextmanager
+from datetime import datetime
 
 
 load_dotenv()
@@ -253,3 +254,11 @@ def fetch_image_data():
 #     #     img["link"] = f"https://e16d722126ccef480a24b7cc683d3e35.r2.cloudflarestorage.com/cloud-test-bucket/{img['file_name']}"  # Link expires in 1 hour
 #     # Render the template with the fetched data
 #     return templates.TemplateResponse("index.html", {"request": request, "images": data})
+
+
+@app.get("/start")
+async def start_endpoint():
+    """
+    Returns the current server datetime.
+    """
+    return {"current_datetime": datetime.now()}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and deploying a Docker image to Azure Container Instances (ACI) and adds a new endpoint to the `main.py` file to return the server's current datetime. Below are the key changes:

### CI/CD Workflow Addition:
* [`.github/workflows/ACR-ACI-push.yml`](diffhunk://#diff-a20158c7517d102b10a9403ca5479526d0fb58d8ec57ffb4f75a782f7aaa4872R1-R40): Added a new GitHub Actions workflow named `ACR-ACI-push` to automate the process of building a Docker image, pushing it to Azure Container Registry (ACR), and deploying it to Azure Container Instances (ACI). This includes steps for checking out the repository, logging into Azure, building and pushing the Docker image, and deploying it to ACI.

### Application Enhancements:
* `main.py`: 
  - Imported the `datetime` module to enable datetime-related functionality.
  - Added a new endpoint `/start` that asynchronously returns the current server datetime in JSON format.